### PR TITLE
Add cleanup for orphaned image files during a refresh and refresh once per new import during rescans

### DIFF
--- a/cbz_tagger/cbz_entity/cbz_scanner.py
+++ b/cbz_tagger/cbz_entity/cbz_scanner.py
@@ -14,8 +14,10 @@ class CbzScanner:
         self.storage_path = storage_path
 
         self.cbz_database = CbzDatabase(root_path=self.config_path, add_missing=add_missing)
+        self.recently_updated = []
 
     def run(self):
+        self.recently_updated = []
         while True:
             completed = self.scan()
             if not completed:
@@ -56,6 +58,11 @@ class CbzScanner:
         print(filepath, manga_name, chapter_number)
 
         try:
+            # If we haven't updated the metadata on this scan, update the metadata records
+            if manga_name not in self.recently_updated:
+                self.cbz_database.update_metadata(manga_name)
+                self.recently_updated.append(manga_name)
+
             entity_name, entity_xml, entity_image_path = self.cbz_database.get_metadata(manga_name, chapter_number)
         except RuntimeError:
             print(f"ERROR >> {manga_name} not in database. Run manual mode to add new series.")

--- a/cbz_tagger/cbz_entity/cbz_scanner.py
+++ b/cbz_tagger/cbz_entity/cbz_scanner.py
@@ -60,7 +60,7 @@ class CbzScanner:
         try:
             # If we haven't updated the metadata on this scan, update the metadata records
             if manga_name not in self.recently_updated:
-                self.cbz_database.update_metadata(manga_name)
+                self.cbz_database.update_metadata(manga_name, save=True)
                 self.recently_updated.append(manga_name)
 
             entity_name, entity_xml, entity_image_path = self.cbz_database.get_metadata(manga_name, chapter_number)

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -52,6 +52,7 @@ class CbzDatabase:
         for manga_name in self.entity_database.entity_map.keys():
             print(f"Refreshing {manga_name}")
             self.update_metadata(manga_name)
+        self.entity_database.clean(self.image_db_path)
         self.save()
 
     def update_metadata(self, manga_name):

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -35,8 +35,11 @@ class CbzDatabase:
         with open(self.entity_db_path, "w", encoding="UTF-8") as write_file:
             write_file.write(entity_database_json)
 
+    def check_manga_exists(self, manga_name):
+        return manga_name in self.entity_database.keys()
+
     def get_metadata(self, manga_name, chapter_number):
-        if manga_name not in self.entity_database.keys():
+        if not self.check_manga_exists(manga_name):
             if not self.add_missing:
                 raise RuntimeError("Manual mode must be enabled for adding missing manga to the database.")
             self.entity_database.add(manga_name)
@@ -56,9 +59,8 @@ class CbzDatabase:
         self.save()
 
     def update_metadata(self, manga_name, save=False):
-        if manga_name not in self.entity_database.keys():
-            if not self.add_missing:
-                raise RuntimeError("Manual mode must be enabled for adding missing manga to the database.")
+        if not self.check_manga_exists(manga_name):
+            return
 
         self.entity_database.update_manga_entity(manga_name, self.image_db_path)
         if save:

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -35,11 +35,11 @@ class CbzDatabase:
         with open(self.entity_db_path, "w", encoding="UTF-8") as write_file:
             write_file.write(entity_database_json)
 
-    def check_manga_exists(self, manga_name):
+    def check_manga_missing(self, manga_name):
         return manga_name in self.entity_database.keys()
 
     def get_metadata(self, manga_name, chapter_number):
-        if not self.check_manga_exists(manga_name):
+        if self.check_manga_missing(manga_name):
             if not self.add_missing:
                 raise RuntimeError("Manual mode must be enabled for adding missing manga to the database.")
             self.entity_database.add(manga_name)
@@ -59,7 +59,7 @@ class CbzDatabase:
         self.save()
 
     def update_metadata(self, manga_name, save=False):
-        if not self.check_manga_exists(manga_name):
+        if self.check_manga_missing(manga_name):
             return
 
         self.entity_database.update_manga_entity(manga_name, self.image_db_path)

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -55,9 +55,11 @@ class CbzDatabase:
         self.entity_database.clean(self.image_db_path)
         self.save()
 
-    def update_metadata(self, manga_name):
+    def update_metadata(self, manga_name, save=False):
         if manga_name not in self.entity_database.keys():
             if not self.add_missing:
                 raise RuntimeError("Manual mode must be enabled for adding missing manga to the database.")
 
         self.entity_database.update_manga_entity(manga_name, self.image_db_path)
+        if save:
+            self.save()

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -56,4 +56,8 @@ class CbzDatabase:
         self.save()
 
     def update_metadata(self, manga_name):
+        if manga_name not in self.entity_database.keys():
+            if not self.add_missing:
+                raise RuntimeError("Manual mode must be enabled for adding missing manga to the database.")
+
         self.entity_database.update_manga_entity(manga_name, self.image_db_path)

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -36,7 +36,7 @@ class CbzDatabase:
             write_file.write(entity_database_json)
 
     def check_manga_missing(self, manga_name):
-        return manga_name in self.entity_database.keys()
+        return manga_name not in self.entity_database.keys()
 
     def get_metadata(self, manga_name, chapter_number):
         if self.check_manga_missing(manga_name):


### PR DESCRIPTION
## DESCRIPTION
This PR does a couple of things:
- Adds the ability to cleanup orphaned files
- Adjusts the logic for checking if a file is missing
- Store a recently updated cache for each `run` operation that will update the seen series metadata once per run (e.g. if you have 50 files for a series it updates it once)
- This update only updates a series picked up in the main scan, not every series, so it should help make `refresh` a lot more efficient in the long-run.

## TODO
I'd like to add some additional cleanup to remove records from the database file, but that will take a bit more thinking as generally this tagger isn't really aware of anything in the `storage` area, so I'm trying to figure out if I should do this.

I need to add some integration testing for the actual scanner I realized...