### PR TITLE
Gracefully handle API down issues

### DIFF
--- a/cbz_tagger/common/helpers.py
+++ b/cbz_tagger/common/helpers.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from time import sleep
 from typing import Any
 from typing import Dict
@@ -28,17 +29,20 @@ def unpaginate_request(url, query_params=None, limit=50) -> List[Dict[str, Any]]
 
     response_content = []
     offset = 0
-    while True:
-        params = {"limit": limit, "offset": offset}
-        params.update(query_params)
+    try:
+        while True:
+            params = {"limit": limit, "offset": offset}
+            params.update(query_params)
 
-        response = requests.get(url, params=params, timeout=60).json()
+            response = requests.get(url, params=params, timeout=60).json()
 
-        response_content.extend(response["data"])
+            response_content.extend(response["data"])
 
-        offset += limit
-        if offset > response["total"]:
-            return response_content
+            offset += limit
+            if offset > response["total"]:
+                return response_content
 
-        # Only make 2 queries per second
-        sleep(0.5)
+            # Only make 2 queries per second
+            sleep(0.5)
+    except JSONDecodeError as exc:
+        raise EnvironmentError("Mangadex API is down! Please try again later!") from exc

--- a/cbz_tagger/database/cbz_database.py
+++ b/cbz_tagger/database/cbz_database.py
@@ -62,6 +62,9 @@ class CbzDatabase:
         if self.check_manga_missing(manga_name):
             return
 
-        self.entity_database.update_manga_entity(manga_name, self.image_db_path)
-        if save:
-            self.save()
+        try:
+            self.entity_database.update_manga_entity(manga_name, self.image_db_path)
+            if save:
+                self.save()
+        except EnvironmentError:
+            print(f"Mangadex API Down >> Unable to update {manga_name} metadata.")


### PR DESCRIPTION
If the mangadex API is down (e.g. returning 503 errors) we should gracefully handle these and not crash the container