### PR TITLE
Migrate most print logic to logger

### DIFF
--- a/cbz_tagger/__init__.py
+++ b/cbz_tagger/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)

--- a/cbz_tagger/__init__.py
+++ b/cbz_tagger/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.INFO)

--- a/cbz_tagger/common/helpers.py
+++ b/cbz_tagger/common/helpers.py
@@ -6,21 +6,6 @@ from cbz_tagger.common.env import AppEnv
 logger = logging.getLogger()
 
 
-def get_input_from_list(desc, input_list, allow_negative_exit=False):
-    print(desc)
-    counter = 0
-    items = list(input_list)
-    for item in items:
-        print(f"{counter + 1}. {item}")
-        counter += 1
-    choice = get_input(
-        "Please select the local and storage name number: ", counter + 1, allow_negative_exit=allow_negative_exit
-    )
-    if choice <= 0:
-        return None
-    return choice - 1
-
-
 def get_input(desc, max_val, allow_negative_exit=False):
     """Allow selection from a list of inputs"""
     while True:

--- a/cbz_tagger/common/helpers.py
+++ b/cbz_tagger/common/helpers.py
@@ -1,6 +1,24 @@
+import logging
 import os
 
 from cbz_tagger.common.env import AppEnv
+
+logger = logging.getLogger()
+
+
+def get_input_from_list(desc, input_list, allow_negative_exit=False):
+    print(desc)
+    counter = 0
+    items = list(input_list)
+    for item in items:
+        print(f"{counter + 1}. {item}")
+        counter += 1
+    choice = get_input(
+        "Please select the local and storage name number: ", counter + 1, allow_negative_exit=allow_negative_exit
+    )
+    if choice <= 0:
+        return None
+    return choice - 1
 
 
 def get_input(desc, max_val, allow_negative_exit=False):
@@ -30,4 +48,4 @@ def set_file_ownership(file_path):
     try:
         os.chown(file_path, int(env.PUID), int(env.PGID))
     except PermissionError as err:
-        print(f"ERROR >> Unable to set permissions on {file_path}, {env.PUID}, {env.PGID}", err)
+        logger.error("ERROR >> Unable to set permissions on %s, %s, %s, %s", file_path, env.PUID, env.PGID, err)

--- a/cbz_tagger/container/container.py
+++ b/cbz_tagger/container/container.py
@@ -1,10 +1,13 @@
 import argparse
+import logging
 import os
 
 from cbz_tagger.common.enums import ContainerMode
 from cbz_tagger.common.env import AppEnv
 from cbz_tagger.container.manual_container import ManualContainer
 from cbz_tagger.container.timer_container import TimerContainer
+
+logger = logging.getLogger()
 
 
 def get_arg_parser():
@@ -38,9 +41,9 @@ def get_environment_variables():
         "environment": env.get_user_environment(),
     }
 
-    print("Environment Variables:")
-    print(env_vars)
-    print(f"proxy_url: {env.PROXY_URL}")
+    logger.info("Environment Variables:")
+    logger.info(env_vars)
+    logger.info("proxy_url: %s", env.PROXY_URL)
 
     return env_vars
 
@@ -55,8 +58,8 @@ def run_container(**kwargs):
         Dictionary from get_arg_parser() containing command line inputs
     """
 
-    print("CBZ Tagger v2.0")
-    print("----------------------")
+    logger.info("CBZ Tagger v3.0")
+    logger.info("----------------------")
 
     env_vars = get_environment_variables()
 

--- a/cbz_tagger/container/manual_container.py
+++ b/cbz_tagger/container/manual_container.py
@@ -1,12 +1,15 @@
+import logging
 import time
 
 from cbz_tagger.container.base_container import BaseContainer
 
+logger = logging.getLogger()
+
 
 class ManualContainer(BaseContainer):
     def _info(self):
-        print("Container running in Manual Scan mode.")
-        print("Manual scans are triggered through the container console.")
+        logger.info("Container running in Manual Scan mode.")
+        logger.info("Manual scans are triggered through the container console.")
 
     def _run(self):
         while True:

--- a/cbz_tagger/container/timer_container.py
+++ b/cbz_tagger/container/timer_container.py
@@ -1,6 +1,9 @@
+import logging
 import time
 
 from cbz_tagger.container.base_container import BaseContainer
+
+logger = logging.getLogger()
 
 
 class TimerContainer(BaseContainer):
@@ -10,9 +13,9 @@ class TimerContainer(BaseContainer):
         self.scanner.add_missing = False
 
     def _info(self):
-        print("Container running in Timer Scan mode.")
-        print("Manual scans can also be triggered through the container console.")
-        print(f"Timer Monitoring with {self.timer_delay}s delay: {self.scan_path}")
+        logger.info("Container running in Timer Scan mode.")
+        logger.info("Manual scans can also be triggered through the container console.")
+        logger.info("Timer Monitoring with %s(s) delay: %s", self.timer_delay, self.scan_path)
 
     def _run(self):
         self.scanner.run()

--- a/cbz_tagger/database/cover_entity_db.py
+++ b/cbz_tagger/database/cover_entity_db.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from io import BytesIO
 from os import path
@@ -8,6 +9,8 @@ from PIL import Image
 
 from cbz_tagger.database.base_db import BaseEntityDB
 from cbz_tagger.entities.cover_entity import CoverEntity
+
+logger = logging.getLogger()
 
 
 class CoverEntityDB(BaseEntityDB):
@@ -57,7 +60,7 @@ class CoverEntityDB(BaseEntityDB):
         for cover in self[entity_id]:
             image_path = path.join(filepath, cover.local_filename)
             if not path.exists(image_path):
-                print(f"Downloading: {cover.cover_url}")
+                logger.info("Downloading: %s", cover.cover_url)
                 image = cover.download_file(cover.cover_url)
                 in_memory_image = Image.open(BytesIO(image))
                 if in_memory_image.format != "JPEG":

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import shutil
@@ -20,6 +21,8 @@ from cbz_tagger.database.cover_entity_db import CoverEntityDB
 from cbz_tagger.database.metadata_entity_db import MetadataEntityDB
 from cbz_tagger.database.volume_entity_db import VolumeEntityDB
 from cbz_tagger.entities.metadata_entity import MetadataEntity
+
+logger = logging.getLogger()
 
 
 class EntityDB:
@@ -201,7 +204,7 @@ class EntityDB:
 
     def remove_entity_id_from_tracking(self, entity_id):
         self.entity_tracked.discard(entity_id)
-        print(f"Removed {entity_id} from tracking.")
+        logger.warning("Removed %s from tracking.", entity_id)
 
         # Remove the downloaded chapters
         downloaded_chapters = []
@@ -210,7 +213,7 @@ class EntityDB:
                 downloaded_chapters.append(chapter)
         for chapter in downloaded_chapters:
             self.entity_downloads.discard(chapter)
-        print(f"Removed downloaded chapters for {entity_id} from tracking.")
+        logger.warning("Removed downloaded chapters for %s from tracking.", entity_id)
 
     def delete_entity_id(self, entity_id_to_remove, entity_name_to_remove):
         self.remove_entity_id_from_tracking(entity_id_to_remove)
@@ -220,7 +223,7 @@ class EntityDB:
         self.covers.database.pop(entity_id_to_remove, None)
         self.volumes.database.pop(entity_id_to_remove, None)
         self.chapters.database.pop(entity_id_to_remove, None)
-        print(f"Deleted entity from database {entity_name_to_remove} ({entity_id_to_remove}).")
+        logger.warning("Deleted entity from database %s (%s).", entity_name_to_remove, entity_id_to_remove)
 
     @staticmethod
     def should_mark_all_tracked(manga_name):
@@ -277,7 +280,7 @@ class EntityDB:
         if entity_id is not None:
             try:
                 chapter_plugin = self.entity_chapter_plugin.get(entity_id, {})
-                print(f"Checking for updates {manga_name}: {entity_id}")
+                logger.info("Checking for updates %s: %s", manga_name, entity_id)
                 last_updated = None
                 latest_chapter = None
                 if self.metadata[entity_id] is not None:
@@ -292,7 +295,7 @@ class EntityDB:
                     return
 
                 # Update the collections
-                print(f"Updating {manga_name}: {entity_id}")
+                logger.info("Updating %s: %s", manga_name, entity_id)
                 self.chapters.update(entity_id, **chapter_plugin)
                 self.volumes.update(entity_id)
                 self.covers.update(entity_id)
@@ -306,17 +309,17 @@ class EntityDB:
                 self.save()
 
             except EnvironmentError as err:
-                print(f"API Down >> Unable to update {manga_name} metadata.", err)
+                logger.info("API Down >> Unable to update %s metadata. %s", manga_name, err)
 
     def refresh(self, storage_path):
-        print("Refreshing database...")
+        logger.info("Refreshing database...")
         for entity_id in sorted(self.metadata.keys()):
             self.update_manga_entity_id(entity_id)
-        print("Cleaning orphaned covers...")
+        logger.info("Cleaning orphaned covers...")
         self.covers.remove_orphaned_covers(self.image_db_path)
-        print("Downloading missing chapters...")
+        logger.info("Downloading missing chapters...")
         self.download_missing_chapters(storage_path)
-        print("Refresh complete.")
+        logger.info("Refresh complete.")
 
     def download_chapter(self, entity_id, chapter_item, storage_path):
         if (entity_id, chapter_item.entity_id) in self.entity_downloads:
@@ -326,7 +329,7 @@ class EntityDB:
         chapter_name = f"{manga_name} - Chapter {chapter_item.padded_chapter_string}"
 
         chapter_filepath = os.path.join(storage_path, manga_name, chapter_name)
-        print(f"Downloading {chapter_name}...")
+        logger.info("Downloading %s...", chapter_name)
         try:
             os.makedirs(chapter_filepath, exist_ok=True)
             # Build the chapter metadata files
@@ -345,7 +348,7 @@ class EntityDB:
             # Set the ownership of the file
             set_file_ownership(f"{chapter_filepath}.cbz")
         except EnvironmentError as err:
-            print(f"Could not download chapter: {entity_id}, {chapter_item.entity_id}", err)
+            logger.info("Could not download chapter: %s, %s, %s", entity_id, chapter_item.entity_id, err)
             if os.path.exists(f"{chapter_filepath}.cbz"):
                 os.remove(f"{chapter_filepath}.cbz")
             if (entity_id, chapter_item.entity_id) in self.entity_downloads:
@@ -474,5 +477,5 @@ class EntityDB:
             try:
                 self.download_chapter(entity_id, chapter_item, storage_path)
             except EnvironmentError as err:
-                print(f"Error occurred in chapter: {entity_id}, {chapter_item.entity_id}", err)
+                logger.error("Error occurred in chapter: %s, %s, %s", entity_id, chapter_item.entity_id, err)
         return missing_chapters

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -396,7 +396,7 @@ class EntityDB:
 
         volume = self.volumes[entity_id].get_volume(chapter_number)
         cover_entity = None
-        if volume != "none":
+        if volume != "-1":
             cover_entity = next((cover for cover in self.covers[entity_id] if cover.volume == volume), None)
         if cover_entity is None:
             cover_art_entity_id = self.metadata[entity_id].cover_art_id

--- a/cbz_tagger/database/file_scanner.py
+++ b/cbz_tagger/database/file_scanner.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import time
@@ -6,6 +7,8 @@ from zipfile import BadZipFile
 
 from cbz_tagger.database.entity_db import EntityDB
 from cbz_tagger.entities.cbz_entity import CbzEntity
+
+logger = logging.getLogger()
 
 
 class FileScanner:
@@ -36,20 +39,20 @@ class FileScanner:
         while True:
             completed = self.scan()
             if not completed:
-                print("Scan not completed. Sleeping 120s")
+                logger.info("Scan not completed. Sleeping 120s")
                 time.sleep(120)
-                print("Initiating rescan...")
+                logger.info("Initiating rescan...")
             else:
-                print("Scan completed.")
+                logger.info("Scan completed.")
                 return
 
     def scan(self):
-        print("Starting scan....")
+        logger.info("Starting scan....")
         for filepath in self.get_cbz_files():
             try:
                 self.process(filepath)
             except BadZipFile:
-                print("Unable to read file... files are either in use or corrupted.")
+                logger.error("Unable to read file... files are either in use or corrupted.")
                 return False
 
         # Remove empty directories
@@ -80,7 +83,7 @@ class FileScanner:
 
     def get_cbz_comicinfo_and_image(self, cbz_entity: CbzEntity):
         manga_name, chapter_number = cbz_entity.get_name_and_chapter()
-        print(cbz_entity.filepath, manga_name, chapter_number)
+        logger.info("%s, %s, %s", cbz_entity.filepath, manga_name, chapter_number)
 
         try:
             # If we haven't updated the metadata on this scan, update the metadata records
@@ -101,7 +104,7 @@ class FileScanner:
             return entity_name, entity_xml, entity_image_path
 
         except (RuntimeError, EnvironmentError) as err:
-            print(f"ERROR >> {manga_name} not in database. Run manual mode to add new series.", err)
+            logger.error("ERROR >> %s not in database. Run manual mode to add new series. %s", manga_name, err)
             return None, None, None
 
     def add_tracked_entity(self):

--- a/cbz_tagger/entities/base_entity.py
+++ b/cbz_tagger/entities/base_entity.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from json import JSONDecodeError
 from time import sleep
 from typing import Any
@@ -10,6 +11,8 @@ import requests
 from cbz_tagger.common.enums import DELAY_PER_REQUEST
 from cbz_tagger.common.enums import Urls
 from cbz_tagger.common.env import AppEnv
+
+logger = logging.getLogger()
 
 
 class BaseEntityObject:
@@ -74,12 +77,12 @@ class BaseEntity(BaseEntityObject):
                     return response
                 # If the status code wasn't success, retry
                 attempt += 1
-                print(f"Error downloading {url}: {response.status_code}. Attempt: {attempt}")
+                logger.error("Error downloading %s: %s. Attempt: %s", url, response.status_code, attempt)
                 sleep(5 * attempt)
             # If the request times out, retry
             except requests.exceptions.Timeout:
                 attempt += 1
-                print(f"Error downloading {url}. Attempt: {attempt}")
+                logger.error("Error downloading %s. Attempt: %s", url, attempt)
                 sleep(5 * attempt)
 
         raise EnvironmentError(f"Failed to receive response from {url} after {retries} attempts")

--- a/cbz_tagger/entities/cbz_entity.py
+++ b/cbz_tagger/entities/cbz_entity.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import re
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 
 from cbz_tagger.common.helpers import set_file_ownership
+
+logger = logging.getLogger()
 
 
 class CbzEntity:
@@ -108,7 +111,7 @@ class CbzEntity:
         cover_image_path = self.get_entity_cover_image_path(entity_image_path)
 
         if os.path.exists(write_path):
-            print("ERROR >> Destination file already present!")
+            logger.error("ERROR >> Destination file already present!")
             return
 
         with ZipFile(read_path, "r") as zip_read:

--- a/cbz_tagger/entities/chapter_plugins/mdx.py
+++ b/cbz_tagger/entities/chapter_plugins/mdx.py
@@ -1,9 +1,12 @@
+import logging
 from time import sleep
 from typing import Any
 from typing import List
 
 from cbz_tagger.common.enums import Urls
 from cbz_tagger.entities.chapter_plugins.plugin import ChapterPluginEntity
+
+logger = logging.getLogger()
 
 
 class ChapterPluginMDX(ChapterPluginEntity):
@@ -41,7 +44,7 @@ class ChapterPluginMDX(ChapterPluginEntity):
 
         # If we didn't retrieve enough pages, try to query again
         if len(response["chapter"][self.quality]) != pages:
-            print("Not enough pages returned from server. Waiting 10s and retrying query.")
+            logger.error("Not enough pages returned from server. Waiting 10s and retrying query.")
             sleep(10)
             response = self.request_with_retry(url).json()
             if len(response["chapter"][self.quality]) != pages:

--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -59,4 +59,4 @@ class VolumeEntity(BaseEntity):
             for chapter in volume_contents:
                 if str(chapter_number) == chapter:
                     return volume
-        return "none"
+        return "-1"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-requests~=2.28.1
+requests~=2.32.3
 watchdog~=2.2.0
-black~=22.12.0
+black~=24.3.0
 isort~=5.12.0
 pylint~=2.15.10
 Pillow~=10.1.0
 pytest~=7.4.2
 requests-mock~=1.12.1
+nicegui~=2.4.0

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -98,8 +98,8 @@ def test_volume_entity_with_broken_chapters(volume_request_response):
             "20",
             "4",
         ),
-        ("30", "none"),
-        ("0", "none"),
+        ("30", "-1"),
+        ("0", "-1"),
     ],
 )
 def test_volume_entity_get_volume_for_chapter(volume_request_response, chapter, expected_volume):


### PR DESCRIPTION
This is part of an initial effort at moving towards a more formalized UI but maintaining the integrity of the backend. This migrates most all the print functionality to use a logger. It should still look relatively similar in manual modes and the console modes, just with the logger prefixes displaying. 

This also fixes handling of the volume property and 2 CVEs.