### PR TITLE
Migrate request calls to scraper

### DIFF
--- a/cbz_tagger/entities/base_entity.py
+++ b/cbz_tagger/entities/base_entity.py
@@ -65,22 +65,18 @@ class BaseEntity(BaseEntityObject):
     @classmethod
     def request_with_retry(cls, url, params=None, retries=3, timeout=30):
         env = AppEnv()
-        request_parameters = {"url": url, "params": params, "headers": cls.base_header, "timeout": timeout}
+        request_parameters = {"url": url, "params": params, "timeout": timeout}
         if env.PROXY_URL is not None:
             request_parameters["proxies"] = {"http": env.PROXY_URL, "https": env.PROXY_URL}
 
         attempt = 0
         while attempt < retries:
             try:
-                response = requests.get(**request_parameters)
+                scraper = cloudscraper.create_scraper()
+                response = scraper.get(**request_parameters)
                 if response.status_code == 200:
                     sleep(DELAY_PER_REQUEST)
                     return response
-                if response.status_code == 403:
-                    scraper = cloudscraper.create_scraper()
-                    scraper_response = scraper.get(url)
-                    if scraper_response.status_code == 200:
-                        return scraper_response
                 # If the status code wasn't success, retry
                 attempt += 1
                 logger.error("Error downloading %s: %s. Attempt: %s", url, response.status_code, attempt)

--- a/cbz_tagger/entities/base_entity.py
+++ b/cbz_tagger/entities/base_entity.py
@@ -68,8 +68,8 @@ class BaseEntity(BaseEntityObject):
         attempt = 0
         while attempt < retries:
             try:
-                scraper = cloudscraper.create_scraper()
-                response = scraper.get(**request_parameters)
+                with cloudscraper.create_scraper() as scraper:
+                    response = scraper.get(**request_parameters)
                 if response.status_code == 200:
                     sleep(DELAY_PER_REQUEST)
                     return response

--- a/cbz_tagger/entities/base_entity.py
+++ b/cbz_tagger/entities/base_entity.py
@@ -18,10 +18,6 @@ logger = logging.getLogger()
 
 class BaseEntityObject:
     base_url = f"https://api.{Urls.MDX}"
-    base_header = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/131.0.0.0 Safari/537.36"
-    }
 
 
 class BaseEntity(BaseEntityObject):

--- a/cbz_tagger/entities/chapter_entity.py
+++ b/cbz_tagger/entities/chapter_entity.py
@@ -101,7 +101,10 @@ class ChapterEntity(BaseEntity):
     @property
     def scanlation_group(self):
         group = next(iter(rel for rel in self.relationships if rel["type"] == "scanlation_group"), {})
-        return group.get("id", "none")
+        scanlation_group = group.get("id", "none")
+        if scanlation_group is None:
+            return "none"
+        return scanlation_group
 
     @property
     def updated(self):

--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -2,8 +2,6 @@ from typing import List
 from typing import Set
 from typing import Tuple
 
-import requests
-
 from cbz_tagger.entities.base_entity import BaseEntity
 
 
@@ -15,8 +13,9 @@ class VolumeEntity(BaseEntity):
     def from_server_url(cls, query_params=None, **kwargs):
         entity_id = query_params["ids[]"][0]
 
-        response = requests.get(f"{cls.entity_url}/{entity_id}/aggregate", timeout=60).json()
-        return [cls(response)]
+        response = cls.request_with_retry(f"{cls.entity_url}/{entity_id}/aggregate")
+        response_json = response.json()
+        return [cls(response_json)]
 
     @property
     def aggregate(self):

--- a/tests/test_unit/test_entities/test_chapter_entity.py
+++ b/tests/test_unit/test_entities/test_chapter_entity.py
@@ -42,3 +42,20 @@ def test_chapter_number_invalid_float(get_chapter_entity):
 def test_chapter_number_missing_entry(get_chapter_entity):
     entity = get_chapter_entity(None)
     assert entity.chapter_number is None
+
+
+def test_scanlation_group(get_chapter_entity):
+    entity = get_chapter_entity("1")
+    assert entity.scanlation_group == "group_id"
+
+
+def test_scanlation_group_with_no_relationships(get_chapter_entity):
+    entity = get_chapter_entity("1")
+    entity.content["relationships"] = []
+    assert entity.scanlation_group == "none"
+
+
+def test_scanlation_group_with_no_defined_group(get_chapter_entity):
+    entity = get_chapter_entity("1")
+    entity.content["relationships"] = [{"type": "scanlation_group", "id": None}]
+    assert entity.scanlation_group == "none"

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -1,6 +1,5 @@
-from unittest import mock
-
 import pytest
+import requests_mock  # pylint: disable=unused-import
 
 from cbz_tagger.entities.volume_entity import VolumeEntity
 
@@ -112,12 +111,13 @@ def test_volume_entity_get_volume_for_chapter(volume_request_response, chapter, 
     assert expected_volume == entity.get_volume(chapter)
 
 
-def test_volume_entity_from_url(volume_request_response):
-    with mock.patch("cbz_tagger.entities.volume_entity.requests") as mock_request:
-        mock_request.get.return_value = mock.Mock(json=mock.MagicMock(return_value=volume_request_response))
-        entities = VolumeEntity.from_server_url(query_params={"ids[]": ["831b12b8-2d0e-4397-8719-1efee4c32f40"]})
-        assert len(entities) == 1
-        assert entities[0].chapter_count == 22
+def test_volume_entity_from_url(volume_request_response, requests_mock):
+    requests_mock.get(
+        f"{VolumeEntity.base_url}/manga/831b12b8-2d0e-4397-8719-1efee4c32f40/aggregate", json=volume_request_response
+    )
+    entities = VolumeEntity.from_server_url(query_params={"ids[]": ["831b12b8-2d0e-4397-8719-1efee4c32f40"]})
+    assert len(entities) == 1
+    assert entities[0].chapter_count == 22
 
 
 def test_volume_entity_can_store_and_load(volume_request_response, check_entity_for_save_and_load):


### PR DESCRIPTION
This is an effort to fix the slew of `403` and other problematic status errors by switching to a `requests` wrapper for all calls. This PR also removes the `mocks` associated with requests and uses `requests_mock` everywhere.