### PR TITLE
Fix cover and volume lookup errors and add basic volume scanning

### DIFF
--- a/cbz_tagger/__init__.py
+++ b/cbz_tagger/__init__.py
@@ -1,4 +1,7 @@
 import logging
 
+from cbz_tagger.common.env import AppEnv
+
+env = AppEnv()
 logger = logging.getLogger()
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=env.LOG_LEVEL)

--- a/cbz_tagger/common/env.py
+++ b/cbz_tagger/common/env.py
@@ -1,4 +1,5 @@
 import getpass
+import logging
 import os
 import platform
 import pwd
@@ -57,6 +58,21 @@ class AppEnv:
         PROXY_URL = None
     else:
         PROXY_URL = os.getenv("PROXY_URL")
+
+    if os.getenv("LOG_LEVEL") is None:
+        LOG_LEVEL = logging.INFO
+    else:
+        level = os.getenv("LOG_LEVEL")
+        if level == "DEBUG":
+            LOG_LEVEL = logging.DEBUG
+        elif level == "INFO":
+            LOG_LEVEL = logging.INFO
+        elif level == "WARNING":
+            LOG_LEVEL = logging.WARNING
+        elif level == "ERROR":
+            LOG_LEVEL = logging.ERROR
+        else:
+            LOG_LEVEL = logging.INFO
 
     def get_user_environment(self):
         return {

--- a/cbz_tagger/common/log_element_handler.py
+++ b/cbz_tagger/common/log_element_handler.py
@@ -6,7 +6,7 @@ from nicegui import ui
 class LogElementHandler(logging.Handler):
     """A logging handler that emits messages to a log element."""
 
-    def __init__(self, element: ui.log, level: int = logging.DEBUG) -> None:
+    def __init__(self, element: ui.log, level: int = logging.NOTSET) -> None:
         self.element = element
         super().__init__(level)
 

--- a/cbz_tagger/database/cover_entity_db.py
+++ b/cbz_tagger/database/cover_entity_db.py
@@ -27,13 +27,6 @@ class CoverEntityDB(BaseEntityDB):
                 covers.append((entity_id, cover_entity.local_filename))
         return covers
 
-    def get_indexed_covers_with_entity_ids(self) -> List[Tuple[str, str]]:
-        covers = []
-        for entity_id, cover_list in self.database.items():
-            for cover_entity in cover_list:
-                covers.append((entity_id, cover_entity.local_filename))
-        return covers
-
     @staticmethod
     def get_local_covers(image_db_path) -> List[str]:
         return sorted(os.listdir(image_db_path))

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -295,6 +295,7 @@ class EntityDB:
         logger.info("Refreshing database...")
         for entity_id in sorted(self.metadata.keys()):
             self.update_manga_entity_id(entity_id)
+        self.download_missing_covers()
         self.remove_orphaned_covers()
         logger.info("Downloading missing chapters...")
         self.download_missing_chapters(storage_path)
@@ -303,6 +304,10 @@ class EntityDB:
     def remove_orphaned_covers(self):
         logger.info("Cleaning orphaned covers...")
         self.covers.remove_orphaned_covers(self.image_db_path)
+
+    def download_missing_covers(self):
+        logger.info("Downloading missing covers...")
+        self.covers.download_missing_covers(self.image_db_path)
 
     def download_chapter(self, entity_id, chapter_item, storage_path):
         if (entity_id, chapter_item.entity_id) in self.entity_downloads:

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -297,16 +297,16 @@ class EntityDB:
             self.update_manga_entity_id(entity_id)
         self.download_missing_covers()
         self.remove_orphaned_covers()
-        logger.info("Downloading missing chapters...")
+        logger.debug("Downloading missing chapters...")
         self.download_missing_chapters(storage_path)
         logger.info("Refresh complete.")
 
     def remove_orphaned_covers(self):
-        logger.info("Cleaning orphaned covers...")
+        logger.debug("Cleaning orphaned covers...")
         self.covers.remove_orphaned_covers(self.image_db_path)
 
     def download_missing_covers(self):
-        logger.info("Downloading missing covers...")
+        logger.debug("Downloading missing covers...")
         self.covers.download_missing_covers(self.image_db_path)
 
     def download_chapter(self, entity_id, chapter_item, storage_path):

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -261,7 +261,7 @@ class EntityDB:
         if entity_id is not None:
             try:
                 chapter_plugin = self.entity_chapter_plugin.get(entity_id, {})
-                logger.info("Checking for updates %s: %s", manga_name, entity_id)
+                logger.debug("Checking for updates %s: %s", manga_name, entity_id)
 
                 previous_content = None
                 if self.metadata[entity_id] is not None:

--- a/cbz_tagger/database/file_scanner.py
+++ b/cbz_tagger/database/file_scanner.py
@@ -105,7 +105,7 @@ class FileScanner:
                 self.recently_updated.append(manga_name)
 
             entity_name, entity_xml, entity_image_path = self.entity_database.get_comicinfo_and_image(
-                manga_name, chapter_number
+                manga_name, chapter_number, chapter_is_volume=cbz_entity.chapter_is_volume
             )
             if entity_name is None:
                 raise RuntimeError(f"ERROR >> {manga_name} not in database. Run manual mode to add new series.")

--- a/cbz_tagger/entities/cbz_entity.py
+++ b/cbz_tagger/entities/cbz_entity.py
@@ -11,11 +11,19 @@ logger = logging.getLogger()
 
 
 class CbzEntity:
-    def __init__(self, filepath: str, config_path: str = "", scan_path: str = "", storage_path: str = ""):
+    def __init__(
+        self,
+        filepath: str,
+        config_path: str = "",
+        scan_path: str = "",
+        storage_path: str = "",
+        chapter_is_volume: bool = False,
+    ):
         self.filepath = filepath
         self.config_path = config_path
         self.scan_path = scan_path
         self.storage_path = storage_path
+        self.chapter_is_volume = chapter_is_volume
 
     def check_path(self):
         if len(os.path.split(self.filepath)) > 2:
@@ -103,6 +111,8 @@ class CbzEntity:
             chapter_number_string = chapter_number_string.zfill(fill)
         else:
             chapter_number_string = chapter_number_string.zfill(3)
+        if self.chapter_is_volume:
+            return os.path.join(self.storage_path, entity_name, f"{entity_name} - Volume {chapter_number_string}.cbz")
         return os.path.join(self.storage_path, entity_name, f"{entity_name} - Chapter {chapter_number_string}.cbz")
 
     def build(self, entity_name, entity_xml, entity_image_path, remove_on_write=True, environment=None):

--- a/cbz_tagger/entities/cbz_entity.py
+++ b/cbz_tagger/entities/cbz_entity.py
@@ -17,13 +17,11 @@ class CbzEntity:
         config_path: str = "",
         scan_path: str = "",
         storage_path: str = "",
-        chapter_is_volume: bool = False,
     ):
         self.filepath = filepath
         self.config_path = config_path
         self.scan_path = scan_path
         self.storage_path = storage_path
-        self.chapter_is_volume = chapter_is_volume
 
     def check_path(self):
         if len(os.path.split(self.filepath)) > 2:
@@ -36,6 +34,17 @@ class CbzEntity:
         self.check_path()
         manga_name = os.path.split(self.filepath)[0]
         return manga_name
+
+    @property
+    def chapter_is_volume(self):
+        """If the volume is removed are there any numbers left? If not this is a volume only entity"""
+        filename = self.chapter_name.replace(".cbz", "")
+        filename = str.lower(filename)
+        filename = re.sub(r"volume \d+", "", filename)
+        filename_numeric_only = re.sub(r"[^0-9.]", "", filename)
+        if len(filename_numeric_only) == 0:
+            return True
+        return False
 
     @property
     def chapter_name(self):
@@ -60,17 +69,18 @@ class CbzEntity:
     @property
     def chapter_number(self) -> str:
         filename = self.chapter_name.replace(".cbz", "")
+        filename = str.lower(filename)
 
         # Check if formatting with chapter title, if so remove the word title
         if filename.find("-") != filename.rfind("-") and filename.find("-") != -1 and filename.rfind("-") != -1:
-            chapter_pos = filename.find("Ch")
+            chapter_pos = filename.find("ch")
             if filename.find("-") < chapter_pos < filename.rfind("-"):
                 filename = filename[: filename.rfind("-")]
 
         filename = re.sub(r"\.\.+", "", filename)
         filename = re.sub(r"\(.*\)", "", filename)
-        filename = re.sub(r"Volume [0-9.].* ", "", filename)
-        filename = re.sub(r"Part [0-9.]", "", filename)
+        filename = re.sub(r"volume \d+ ", "", filename)
+        filename = re.sub(r"part \d+", "", filename)
         filename_numeric_only = re.sub(r"[^0-9.]", " ", filename)
         valid_parts = [p for p in filename_numeric_only.split(" ") if len(p) > 0]
         valid_parts = [self.convert_to_number(p) for p in valid_parts if self.convert_to_number(p) is not None]

--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -44,6 +44,9 @@ class VolumeEntity(BaseEntity):
             volume_list.append((volume_key, min(volume), max(volume)))
 
         volume_list = sorted(volume_list, key=lambda x: float(x[0]))
+        if len(volume_list) == 0:
+            return [("-1", 0.0, 0.0)]
+
         final_volume_chapter = volume_list[-1][2] + 1.0
         volume_ends = [item[1] for item in volume_list][1:] + [final_volume_chapter]
 

--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -54,6 +54,10 @@ class VolumeEntity(BaseEntity):
         return volume_map
 
     @property
+    def last_volume(self):
+        return max(int(key) for key in self.volumes if key != "none")
+
+    @property
     def chapters(self) -> Set[str]:
         chapters = set()
         for volume_chapters in self.volumes.values():

--- a/cbz_tagger/gui/elements/config_table.py
+++ b/cbz_tagger/gui/elements/config_table.py
@@ -31,5 +31,6 @@ def config_table():
             {"property": "PUID", "value": env.PUID},
             {"property": "PGID", "value": env.PGID},
             {"property": "UMASK", "value": env.UMASK},
+            {"property": "LOG_LEVEL", "value": env.LOG_LEVEL},
         ],
     )

--- a/cbz_tagger/gui/elements/ui_logger.py
+++ b/cbz_tagger/gui/elements/ui_logger.py
@@ -2,15 +2,16 @@ import logging
 
 from nicegui import ui
 
+from cbz_tagger import AppEnv
 from cbz_tagger.common.log_element_handler import LogElementHandler
 
 logger = logging.getLogger()
 
 
 def ui_logger():
+    env = AppEnv()
     log = ui.log(max_lines=1000).classes("w-full").style("height: 70vh")
-    handler = LogElementHandler(log)
-    handler.setLevel(logging.INFO)
+    handler = LogElementHandler(log, level=env.LOG_LEVEL)
     logger.addHandler(handler)
 
     return log

--- a/cbz_tagger/gui/simple_gui.py
+++ b/cbz_tagger/gui/simple_gui.py
@@ -21,7 +21,7 @@ logger = logging.getLogger()
 
 class SimpleGui:
     def __init__(self, scanner):
-        logger.info("Starting GUI")
+        logger.debug("Starting GUI")
         self.env = AppEnv()
         self.first_scan = True
         self.scanning_state = False
@@ -222,7 +222,7 @@ class SimpleGui:
         self.gui_elements["selector_delete_series"].value = self.gui_elements["selector_delete_series"].options[0]
 
     def refresh_table(self):
-        logger.info("Refreshing series table")
+        logger.debug("Refreshing series table")
         self.scanner.reload_scanner()
         state = self.scanner.to_state()
         formatted_state = []
@@ -231,7 +231,7 @@ class SimpleGui:
                 item["entity_name"] = item["entity_name"][:50] + "..."
             formatted_state.append(item)
         self.gui_elements["table_series"].rows = formatted_state
-        logger.info("Series GUI Refreshed")
+        logger.debug("Series GUI Refreshed")
 
     def can_use_database(self):
         if self.scanning_state:
@@ -307,7 +307,7 @@ class SimpleGui:
     async def refresh_database(self):
         if self.first_scan:
             self.first_scan = False
-            logger.info("Timer setup scan triggered. Skipping startup run.")
+            logger.debug("Timer setup scan triggered. Skipping startup run.")
             return
         notify_and_log("Refreshing database... please wait")
 

--- a/cbz_tagger/gui/simple_gui.py
+++ b/cbz_tagger/gui/simple_gui.py
@@ -298,7 +298,7 @@ class SimpleGui:
         choices = [f"{name} ({entity_id})" for name, entity_id in self.delete_series_ids]
         entity_index = choices.index(self.gui_elements["selector_delete_series"].value)
         entity_name_to_remove, entity_id_to_remove = self.delete_series_ids[entity_index]
-        notify_and_log(f"Removing {entity_name_to_remove} from the database...")
+        logger.info("Removing %s from the database...", entity_name_to_remove)
         self.scanner.entity_database.delete_entity_id(entity_id_to_remove, entity_name_to_remove)
         notify_and_log(f"Removed {entity_name_to_remove} from the database")
         self.refresh_delete_series()

--- a/tests/test_unit/test_cbz_entity/test_cbz_entity.py
+++ b/tests/test_unit/test_cbz_entity/test_cbz_entity.py
@@ -116,6 +116,36 @@ def test_chapter_name_parsing(filename, expected):
 
 
 @pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("Simple Name/Simple name - 1.cbz", False),
+        ("Simple Name/Simple name - 1.1.cbz", False),
+        ("Simple Name/Simple name - 1.2.cbz", False),
+        ("Simple Name/Simple name - 001.cbz", False),
+        ("Simple Name/Simple name - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Chapter 1.1.cbz", False),
+        ("Simple Name/Simple name - Chapter 1.2.cbz", False),
+        ("Simple Name/Simple name - Chapter 001.cbz", False),
+        ("Simple Name/Simple name - Volume 1 - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Volume 01 - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Volume 001 - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Volume 10 - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Volume 12 - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Volume 101 - Chapter 1.cbz", False),
+        ("Simple Name/Simple name - Volume 1.cbz", True),
+        ("Simple Name/Simple name - Volume 01.cbz", True),
+        ("Simple Name/Simple name - Volume 001.cbz", True),
+        ("Simple Name/Simple name - Volume 10.cbz", True),
+        ("Simple Name/Simple name - Volume 12.cbz", True),
+        ("Simple Name/Simple name - Volume 101.cbz", True),
+    ],
+)
+def test_chapter_is_volume_parsing(filename, expected):
+    entity = CbzEntity(filename)
+    assert entity.chapter_is_volume == expected
+
+
+@pytest.mark.parametrize(
     "chapter_prefix",
     [
         "Simple name",
@@ -126,6 +156,7 @@ def test_chapter_name_parsing(filename, expected):
         "Simple name 123",
         "Simple name #1",
         "Simple name .01",
+        "Simple name - Volume 1",
     ],
 )
 @pytest.mark.parametrize(
@@ -184,11 +215,13 @@ def test_chapter_number_parsing(
     filename = f"{chapter_prefix}/{chapter_prefix}{chapter_delimiter}{chapter_number_prefix}{chapter_number}{chapter_suffix}.cbz"
     entity = CbzEntity(filename)
     assert entity.chapter_number == expected
+    assert not entity.chapter_is_volume
 
     # Test \\ pathing
     filename = f"{chapter_prefix}\\{chapter_prefix}{chapter_delimiter}{chapter_number_prefix}{chapter_number}{chapter_suffix}.cbz"
     entity = CbzEntity(filename)
     assert entity.chapter_number == expected
+    assert not entity.chapter_is_volume
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_database/conftest.py
+++ b/tests/test_unit/test_database/conftest.py
@@ -99,6 +99,7 @@ def mock_entity_db_with_mock_updates(mock_entity_db, manga_request_id, manga_req
     mock_entity_db.authors.update = mock.MagicMock()
     mock_entity_db.covers.update = mock.MagicMock()
     mock_entity_db.covers.download = mock.MagicMock()
+    mock_entity_db.covers.download_missing_covers = mock.MagicMock()
     mock_entity_db.volumes.update = mock.MagicMock()
     mock_entity_db.chapters.update = mock.MagicMock()
     mock_entity_db.metadata.database[manga_request_id] = metadata_entity

--- a/tests/test_unit/test_database/test_cover_entity_db.py
+++ b/tests/test_unit/test_database/test_cover_entity_db.py
@@ -1,0 +1,112 @@
+import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from PIL.Image import Image
+
+from cbz_tagger.database.cover_entity_db import CoverEntityDB
+from cbz_tagger.entities.cover_entity import CoverEntity
+
+
+@pytest.fixture
+def cover_entity_db():
+    test_db = CoverEntityDB()
+    test_db.database = {
+        "entity1": [MagicMock(local_filename="cover1.jpg"), MagicMock(local_filename="cover2.jpg")],
+        "entity2": [MagicMock(local_filename="cover3.jpg")],
+    }
+    return test_db
+
+
+def test_get_indexed_covers(cover_entity_db):
+    covers = cover_entity_db.get_indexed_covers()
+    expected_covers = [("entity1", "cover1.jpg"), ("entity1", "cover2.jpg"), ("entity2", "cover3.jpg")]
+    assert covers == expected_covers
+
+
+def test_get_indexed_covers_with_entity_ids(cover_entity_db):
+    covers = cover_entity_db.get_indexed_covers_with_entity_ids()
+    expected_covers = [("entity1", "cover1.jpg"), ("entity1", "cover2.jpg"), ("entity2", "cover3.jpg")]
+    assert covers == expected_covers
+
+
+@patch("os.listdir")
+def test_get_local_covers(mock_listdir):
+    mock_listdir.return_value = ["cover1.jpg", "cover2.jpg", "cover3.jpg"]
+    local_covers = CoverEntityDB.get_local_covers("mock_path")
+    assert local_covers == ["cover1.jpg", "cover2.jpg", "cover3.jpg"]
+
+
+def test_get_orphaned_covers(cover_entity_db):
+    with patch(
+        "cbz_tagger.database.cover_entity_db.CoverEntityDB.get_local_covers",
+        return_value=["cover1.jpg", "cover3.jpg", "cover4.jpg"],
+    ):
+        orphaned_covers = cover_entity_db.get_orphaned_covers("mock_path")
+        assert orphaned_covers == ["cover4.jpg"]
+
+
+@patch("os.remove")
+def test_remove_orphaned_covers(mock_remove, cover_entity_db):
+    with patch("cbz_tagger.database.cover_entity_db.CoverEntityDB.get_orphaned_covers", return_value=["cover4.jpg"]):
+        cover_entity_db.remove_orphaned_covers("mock_path")
+        mock_remove.assert_called_once_with(os.path.join("mock_path", "cover4.jpg"))
+
+
+def test_get_missing_covers(cover_entity_db):
+    with patch("cbz_tagger.database.cover_entity_db.CoverEntityDB.get_local_covers", return_value=["cover1.jpg"]):
+        missing_covers = cover_entity_db.get_missing_covers("mock_path")
+        assert missing_covers == {"entity1", "entity2"}
+
+
+@patch("cbz_tagger.database.cover_entity_db.CoverEntityDB.download")
+def test_download_missing_covers(mock_download, cover_entity_db):
+    with patch("cbz_tagger.database.cover_entity_db.CoverEntityDB.get_missing_covers", return_value={"entity1"}):
+        cover_entity_db.download_missing_covers("mock_path")
+        mock_download.assert_called_once_with("entity1", "mock_path")
+
+
+@pytest.mark.parametrize(
+    "content, expected_locale",
+    [
+        ([MagicMock(attributes={"locale": "ja"})], "ja"),
+        ([MagicMock(attributes={"locale": "en"})], "en"),
+        ([MagicMock(attributes={"locale": "ko"})], "ko"),
+        ([MagicMock(attributes={"locale": "zh"})], "zh"),
+        ([MagicMock(attributes={"locale": "fr"})], "fr"),
+    ],
+)
+def test_format_content_for_entity(content, expected_locale):
+    test_db = CoverEntityDB()
+    result = test_db.format_content_for_entity(content)
+    assert len(result) == 1
+    assert result[0].attributes["locale"] == expected_locale
+
+
+@patch("cbz_tagger.database.cover_entity_db.os.makedirs")
+@patch("cbz_tagger.database.cover_entity_db.path.exists")
+@patch("cbz_tagger.database.cover_entity_db.Image.open")
+@patch("cbz_tagger.database.cover_entity_db.BytesIO")
+def test_download(mock_bytes_io, mock_image_open, mock_path_exists, mock_os_makedirs):
+    mock_cover = MagicMock(spec=CoverEntity)
+    mock_cover.local_filename = "cover1.jpg"
+    mock_cover.cover_url = "http://example.com/cover1.jpg"
+    mock_cover.download_file.return_value = b"image_data"
+
+    mock_image = MagicMock(spec=Image)
+    mock_image.format = "JPEG"
+    mock_image_open.return_value = mock_image
+
+    test_db = CoverEntityDB()
+    test_db.database = {"entity1": [mock_cover]}
+
+    mock_path_exists.side_effect = lambda x: x != "mock_path/cover1.jpg"
+
+    test_db.download("entity1", "mock_path")
+
+    mock_os_makedirs.assert_called_once_with("mock_path", exist_ok=True)
+    mock_cover.download_file.assert_called_once_with("http://example.com/cover1.jpg")
+    mock_bytes_io.assert_called_once_with(b"image_data")
+    mock_image_open.assert_called_once_with(mock_bytes_io())
+    mock_image.save.assert_called_once_with("mock_path/cover1.jpg", quality=95, optimize=True)

--- a/tests/test_unit/test_database/test_cover_entity_db.py
+++ b/tests/test_unit/test_database/test_cover_entity_db.py
@@ -25,12 +25,6 @@ def test_get_indexed_covers(cover_entity_db):
     assert covers == expected_covers
 
 
-def test_get_indexed_covers_with_entity_ids(cover_entity_db):
-    covers = cover_entity_db.get_indexed_covers_with_entity_ids()
-    expected_covers = [("entity1", "cover1.jpg"), ("entity1", "cover2.jpg"), ("entity2", "cover3.jpg")]
-    assert covers == expected_covers
-
-
 @patch("os.listdir")
 def test_get_local_covers(mock_listdir):
     mock_listdir.return_value = ["cover1.jpg", "cover2.jpg", "cover3.jpg"]

--- a/tests/test_unit/test_database/test_entity_db.py
+++ b/tests/test_unit/test_database/test_entity_db.py
@@ -459,3 +459,29 @@ def test_entity_database_calls_downloads_for_missing_chapters(mock_entity_db, ma
     mock_entity_db.download_chapter = mock.MagicMock()
     mock_entity_db.download_missing_chapters("storage_path")
     assert mock_entity_db.download_chapter.call_count == 4
+
+
+@mock.patch("cbz_tagger.database.entity_db.EntityDB.update_manga_entity_id")
+@mock.patch("cbz_tagger.database.entity_db.EntityDB.download_missing_covers")
+@mock.patch("cbz_tagger.database.entity_db.EntityDB.remove_orphaned_covers")
+@mock.patch("cbz_tagger.database.entity_db.EntityDB.download_missing_chapters")
+def test_refresh(
+    mock_download_missing_chapters,
+    mock_remove_orphaned_covers,
+    mock_download_missing_covers,
+    mock_update_manga_entity_id,
+):
+    mock_metadata = mock.MagicMock()
+    mock_metadata.keys.return_value = ["entity1", "entity2"]
+
+    entity_db = EntityDB(root_path="mock_path")
+    entity_db.metadata = mock_metadata
+
+    storage_path = "mock_storage_path"
+    entity_db.refresh(storage_path)
+
+    mock_update_manga_entity_id.assert_any_call("entity1")
+    mock_update_manga_entity_id.assert_any_call("entity2")
+    mock_download_missing_covers.assert_called_once()
+    mock_remove_orphaned_covers.assert_called_once()
+    mock_download_missing_chapters.assert_called_once_with(storage_path)

--- a/tests/test_unit/test_gui/test_config_table.py
+++ b/tests/test_unit/test_gui/test_config_table.py
@@ -17,6 +17,7 @@ def test_config_table(mock_ui_table, mock_app_env):
     mock_env.PUID = "mock_puid"
     mock_env.PGID = "mock_pgid"
     mock_env.UMASK = "mock_umask"
+    mock_env.LOG_LEVEL = 20
     mock_app_env.return_value = mock_env
 
     config_table()
@@ -35,6 +36,7 @@ def test_config_table(mock_ui_table, mock_app_env):
         {"property": "PUID", "value": "mock_puid"},
         {"property": "PGID", "value": "mock_pgid"},
         {"property": "UMASK", "value": "mock_umask"},
+        {"property": "LOG_LEVEL", "value": 20},
     ]
 
     mock_ui_table.assert_called_once_with(columns=expected_columns, rows=expected_rows)

--- a/tests/test_unit/test_gui/test_ui_logger.py
+++ b/tests/test_unit/test_gui/test_ui_logger.py
@@ -1,4 +1,5 @@
 import logging
+from unittest import mock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -15,6 +16,6 @@ def test_ui_logger(mock_log_element_handler, mock_ui_log):
 
     ui_logger()
 
+    mock_log_element_handler.assert_called_once_with(mock.ANY, level=logging.INFO)
     mock_ui_log.assert_called_once_with(max_lines=1000)
     mock_log.classes.assert_called_once_with("w-full")
-    mock_handler.setLevel.assert_called_once_with(logging.INFO)


### PR DESCRIPTION
* Handle scenarios when there are no volumes at all in a lookup
* Handle missing covers by just re-retrieving them
* Add basic support for scanning and importing "volume only" mode. This can only be done in a manual scan.
* Add better cover entity db testing. These tests were very weak
* Fix log level handling and move primary spam to debug only level