### PR TITLE
Add synthetic volume concept

### DIFF
--- a/cbz_tagger/database/cover_entity_db.py
+++ b/cbz_tagger/database/cover_entity_db.py
@@ -85,3 +85,16 @@ class CoverEntityDB(BaseEntityDB):
                 if in_memory_image.format != "JPEG":
                     in_memory_image = in_memory_image.convert("RGB")
                 in_memory_image.save(image_path, quality=95, optimize=True)
+
+    def get_cover_for_volume(self, entity_id, volume, default_cover_art_id):
+        covers = self[entity_id]
+        cover_entity = None
+        if volume != "-1":
+            cover_entity = next((cover for cover in covers if cover.volume == volume), None)
+        if cover_entity is None:
+            cover_entity = next((cover for cover in covers if cover.entity_id == default_cover_art_id), None)
+            # If the art id was associated as a bad language in the databases, try to find the latest cover
+            if cover_entity is None:
+                cover_entity = self.get_latest_cover_for_entity(entity_id)
+
+        return cover_entity

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -394,18 +394,8 @@ class EntityDB:
             volume = str(int(chapter_number))
         else:
             volume = self.volumes[entity_id].get_volume(chapter_number)
-        cover_entity = None
-        if volume != "-1":
-            cover_entity = next((cover for cover in self.covers[entity_id] if cover.volume == volume), None)
-        if cover_entity is None:
-            cover_art_entity_id = self.metadata[entity_id].cover_art_id
-            cover_entity = next(
-                (cover for cover in self.covers[entity_id] if cover.entity_id == cover_art_entity_id), None
-            )
-            # If the art id was associated as a bad language in the databases, try to find the latest cover
-            if cover_entity is None:
-                cover_entity = self.covers.get_latest_cover_for_entity(entity_id)
 
+        cover_entity = self.covers.get_cover_for_volume(entity_id, volume, self.metadata[entity_id].cover_art_id)
         return cover_entity.local_filename if cover_entity else None
 
     def to_xml_tree(self, manga_name, chapter_number, chapter_is_volume=False) -> ElementTree:

--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -83,16 +83,14 @@ class VolumeEntity(BaseEntity):
         return len(self.chapters)
 
     def get_volume(self, chapter_number: str) -> str:
+        if len(self.volume_map) == 0:
+            return "-1"
+
         for volume_number, volume_start, volume_end in self.volume_map:
             if volume_start <= math.floor(float(chapter_number)) < volume_end:
                 return volume_number
 
-        return self.get_synthetic_volume(chapter_number)
-
-    def get_synthetic_volume(self, chapter_number: str) -> str:
-        if len(self.volume_map) == 0:
-            return "-1"
-
+        # Attempt to allocate a synthetic volume
         chapter_num = float(chapter_number)
         if chapter_num > self.last_volume:
             # Determine the maximum chapters in a known volume

--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -87,4 +87,22 @@ class VolumeEntity(BaseEntity):
             if volume_start <= math.floor(float(chapter_number)) < volume_end:
                 return volume_number
 
+        return self.get_synthetic_volume(chapter_number)
+
+    def get_synthetic_volume(self, chapter_number: str) -> str:
+        if len(self.volume_map) == 0:
+            return "-1"
+
+        chapter_num = float(chapter_number)
+        if chapter_num > self.last_volume:
+            # Determine the maximum chapters in a known volume
+            max_volume_step = float(max(end - start for _, start, end in self.volume_map))
+            last_volume = int(self.volume_map[-1][0])
+            last_volume_chapter = float(self.volume_map[-1][2])
+            # Determine the number of synthetic volumes
+            synthetic_volumes = math.ceil((chapter_num - last_volume_chapter) / max_volume_step)
+            if synthetic_volumes == 0:
+                synthetic_volumes += 1
+            return str(int(last_volume + synthetic_volumes))
+
         return "-1"

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -88,10 +88,10 @@ def test_volume_entity_with_broken_chapters(volume_request_response):
         ("20", "4"),
         ("21", "4"),
         ("21.5", "4"),
-        ("22", "-1"),
-        ("30", "-1"),
+        ("22", "5"),
+        ("30", "5"),
+        ("100", "12"),
         ("0", "-1"),
-        ("100", "-1"),
     ],
 )
 def test_volume_entity_get_volume_for_chapter(volume_request_response, chapter, expected_volume):

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -90,6 +90,8 @@ def test_volume_entity_with_broken_chapters(volume_request_response):
         ("21.5", "4"),
         ("22", "5"),
         ("30", "5"),
+        ("40", "6"),
+        ("50", "7"),
         ("100", "12"),
         ("0", "-1"),
     ],

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -90,6 +90,7 @@ def test_volume_entity_with_broken_chapters(volume_request_response):
         ("21.5", "4"),
         ("22", "5"),
         ("30", "5"),
+        ("30.5", "5"),
         ("40", "6"),
         ("50", "7"),
         ("100", "12"),


### PR DESCRIPTION
This adds a sort of unique concept I came up with thinking about some poorly formatted metadata. In some cases there are chapters and volumes released that fall outside the scope of the volume and chapter metadata. This makes it impossible to directly look up a chapter and associate the correct cover. In cases like this we could however construct a `synthetic volume` and attempt to find a cover that matches this synthetic volume (as covers always have an associated volume).

Because we don't really know what would or would not be contained exactly in this volume, we approximate the number of chapters in each `synthetic volume` as being the maximum number of whole digit chapters we have observed at any point in the history of the metadata. The synthetic volume is then computed as the number of these steps added to the last known volume. In a lot of cases this synthetic calculation will probably result in a `volume` that doesn't exist within the space of the known covers, and will ultimately be resolved to the default cover entity (or the cover/volume equivalent of "-1"), but if there are covers that aren't properly registered this can help to better structure the existing files.