### PR TITLE
Fix volume lookup with no volumes

### DIFF
--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -86,6 +86,9 @@ class VolumeEntity(BaseEntity):
         if len(self.volume_map) == 0:
             return "-1"
 
+        if len(self.volume_map) == 1 and self.volume_map[0][0] == "-1":
+            return "-1"
+
         for volume_number, volume_start, volume_end in self.volume_map:
             if volume_start <= math.floor(float(chapter_number)) < volume_end:
                 return volume_number

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -102,6 +102,12 @@ def test_volume_entity_get_volume_for_chapter(volume_request_response, chapter, 
     assert expected_volume == entity.get_volume(chapter)
 
 
+def test_volume_entity_get_volume_for_chapter_with_no_volume_map():
+    entity = VolumeEntity(content={"result": "ok", "volumes": {}})
+    assert "-1" == entity.get_volume("1")
+    assert "-1" == entity.get_volume("10")
+
+
 def test_volume_entity_from_url(volume_request_response, requests_mock):
     requests_mock.get(
         f"{VolumeEntity.base_url}/manga/831b12b8-2d0e-4397-8719-1efee4c32f40/aggregate", json=volume_request_response


### PR DESCRIPTION
Edge case allows volumes to not exist when there is only a single negative volume present