### PR TITLE
Fix series list sorting

### DIFF
--- a/cbz_tagger/common/enums.py
+++ b/cbz_tagger/common/enums.py
@@ -21,6 +21,7 @@ class Urls:
     MDX = base64.b64decode("bWFuZ2FkZXgub3Jn").decode("utf-8")
     MSE = base64.b64decode("bWFuZ2FzZWUxMjMuY29t").decode("utf-8")
     CMK = base64.b64decode("YXBpLmNvbWljay5mdW4=").decode("utf-8")
+    CMK_TITLE = base64.b64decode("Y29taWNrLmlv").decode("utf-8")
     WBC = base64.b64decode("d2VlYmNlbnRyYWwuY29t").decode("utf-8")
 
 
@@ -33,7 +34,7 @@ class Plugins:
     TITLE_URLS = {
         MDX: f"https://{Urls.MDX}/title/",
         MSE: f"https://{Urls.MSE}/manga/",
-        CMK: f"https://{Urls.CMK}/comic/",
+        CMK: f"https://{Urls.CMK_TITLE}/comic/",
         WBC: f"https://{Urls.WBC}/series/",
     }
 

--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -148,6 +148,7 @@ class EntityDB:
                     "tracked": Emoji.CIRCLE_GREEN if entity_id in self.entity_tracked else Emoji.CIRCLE_BROWN,
                 }
             )
+        state = sorted(state, key=lambda d: d["entity_name"]["name"].lower())
         return state
 
     def check_manga_missing(self, manga_name):

--- a/cbz_tagger/gui/elements/series_table.py
+++ b/cbz_tagger/gui/elements/series_table.py
@@ -9,7 +9,6 @@ def series_table():
             "field": "entity_name",
             "required": True,
             "align": "left",
-            "sortable": True,
         },
         {
             "name": "entity_id",

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -17,7 +17,7 @@ def check_entity_download_links(entity, entity_link_count):
     [
         ("11afa5c2-41dc-4cf3-8451-f306a3caf1ab", Plugins.MDX, "", 132, 7, 7),
         ("example_manga", Plugins.CMK, "itadaki", 5, 21, 20),
-        ("example_manga", Plugins.MSE, "Itadaki", 5, 21, 20),
+        # ("example_manga", Plugins.MSE, "Itadaki", 5, 21, 20), # Disabled
         ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
     ],
 )

--- a/tests/test_unit/test_database/test_individual_entity_dbs.py
+++ b/tests/test_unit/test_database/test_individual_entity_dbs.py
@@ -85,7 +85,7 @@ def test_volume_entity_db(volume_request_response, manga_request_id):
 
 
 def test_volume_entity_db_can_store_and_load(volume_request_response, manga_request_id):
-    with mock.patch.object(MetadataEntity, "from_server_url") as mock_from_server_url:
+    with mock.patch.object(VolumeEntity, "from_server_url") as mock_from_server_url:
         mock_from_server_url.return_value = [VolumeEntity(content=volume_request_response)]
         entity_db = VolumeEntityDB()
         entity_db.update(manga_request_id)

--- a/tests/test_unit/test_gui/test_series_table.py
+++ b/tests/test_unit/test_gui/test_series_table.py
@@ -19,7 +19,6 @@ def test_series_table(mock_ui_table):
             "field": "entity_name",
             "required": True,
             "align": "left",
-            "sortable": True,
         },
         {
             "name": "entity_id",


### PR DESCRIPTION
Fixes the following issues:
- Main series list sorting was totally random, its now alphabetic
- Removed the "sortable" attribute since a list of dicts can't be sorted by nicegui
- Fixed a leaking test
- Fixed the CMK redirect on the series id to not point to the API directly (makes page just json)
- Disable MSE in testing, need to remove everything in a followup