### PR TITLE
Make official preferred group when sorting for groups, even if it is not highest frequency

### DIFF
--- a/cbz_tagger/database/chapter_entity_db.py
+++ b/cbz_tagger/database/chapter_entity_db.py
@@ -27,6 +27,7 @@ class ChapterEntityDB(BaseEntityDB):
 
     @staticmethod
     def get_priority_scanlation_groups(scanlation_groups):
+        """For groups with same frequency they are sorted in descending alphabetic order"""
         scanlation_group_frequency = {group: scanlation_groups.count(group) for group in scanlation_groups}
         priority_groups = [
             group
@@ -34,6 +35,8 @@ class ChapterEntityDB(BaseEntityDB):
                 [(value, group) for group, value in scanlation_group_frequency.items()], reverse=True
             )
         ]
+        if "official" in priority_groups:
+            priority_groups.insert(0, priority_groups.pop(priority_groups.index("official")))
         return priority_groups
 
     @staticmethod

--- a/cbz_tagger/entities/chapter_entity.py
+++ b/cbz_tagger/entities/chapter_entity.py
@@ -97,12 +97,12 @@ class ChapterEntity(BaseEntity):
         return self.attributes.get("pages")
 
     @property
-    def scanlation_group(self):
+    def scanlation_group(self) -> str:
         group = next(iter(rel for rel in self.relationships if rel["type"] == "scanlation_group"), {})
         scanlation_group = group.get("id", "none")
         if scanlation_group is None:
             return "none"
-        return scanlation_group
+        return scanlation_group.lower()
 
     @property
     def updated(self):

--- a/tests/test_integration/test_cbz_scanning.py
+++ b/tests/test_integration/test_cbz_scanning.py
@@ -30,10 +30,10 @@ def test_process_cbz_files(mock_get_input, integration_scanner, build_test_cbz):
         for root, dirs, files in os.walk(integration_scanner.storage_path)
         for name in files
     ]
-    assert storage_results == [
+    assert set(storage_results) == {
         "Touto Sugite Yome na a a a a a a i 4P Short Stories/"
         "Touto Sugite Yome na a a a a a a i 4P Short Stories - Chapter 001.cbz"
-    ]
+    }
 
     # Create a test cbz file for chapter 2, use existing metadata and process it
     build_test_cbz(2)

--- a/tests/test_integration/test_cbz_scanning.py
+++ b/tests/test_integration/test_cbz_scanning.py
@@ -44,12 +44,12 @@ def test_process_cbz_files(mock_get_input, integration_scanner, build_test_cbz):
         for root, dirs, files in os.walk(integration_scanner.storage_path)
         for name in files
     ]
-    assert storage_results == [
+    assert set(storage_results) == {
         "Touto Sugite Yome na a a a a a a i 4P Short Stories/"
         "Touto Sugite Yome na a a a a a a i 4P Short Stories - Chapter 001.cbz",
         "Touto Sugite Yome na a a a a a a i 4P Short Stories/"
         "Touto Sugite Yome na a a a a a a i 4P Short Stories - Chapter 002.cbz",
-    ]
+    }
 
 
 def test_process_cbz_files_with_no_files(integration_scanner):

--- a/tests/test_unit/test_database/test_chapter_entity_db.py
+++ b/tests/test_unit/test_database/test_chapter_entity_db.py
@@ -49,7 +49,7 @@ def test_chapter_entity_db_can_store_and_load(chapter_request_response, manga_re
         assert json_str == new_json_str
 
 
-def test_group_chapters():
+def test_group_chapters_individually():
     chapter_a = ChapterEntity(
         content={
             "attributes": {
@@ -78,3 +78,117 @@ def test_group_chapters():
         3.0: [chapter_c],
     }
     assert scanlation_groups == ["group1", "group2", "group3"]
+
+
+def test_group_chapters_with_duplicate_number():
+    chapter_a = ChapterEntity(
+        content={
+            "attributes": {
+                "chapter": "1",
+                "translatedLanguage": "en",
+            },
+            "relationships": [{"type": "scanlation_group", "id": "group1"}],
+        }
+    )
+    chapter_b = ChapterEntity(
+        content={
+            "attributes": {"chapter": "1", "translatedLanguage": "en"},
+            "relationships": [{"type": "scanlation_group", "id": "group2"}],
+        }
+    )
+    chapter_c = ChapterEntity(
+        content={
+            "attributes": {"chapter": "2", "translatedLanguage": "en"},
+            "relationships": [{"type": "scanlation_group", "id": "group3"}],
+        }
+    )
+    grouped_chapters, scanlation_groups = ChapterEntityDB.group_chapters([chapter_a, chapter_b, chapter_c])
+    assert grouped_chapters == {
+        1.0: [chapter_a, chapter_b],
+        2.0: [chapter_c],
+    }
+    assert scanlation_groups == ["group1", "group2", "group3"]
+
+
+def test_group_chapters_with_duplicate_group():
+    chapter_a = ChapterEntity(
+        content={
+            "attributes": {
+                "chapter": "1",
+                "translatedLanguage": "en",
+            },
+            "relationships": [{"type": "scanlation_group", "id": "group1"}],
+        }
+    )
+    chapter_b = ChapterEntity(
+        content={
+            "attributes": {"chapter": "2", "translatedLanguage": "en"},
+            "relationships": [{"type": "scanlation_group", "id": "group1"}],
+        }
+    )
+    chapter_c = ChapterEntity(
+        content={
+            "attributes": {"chapter": "3", "translatedLanguage": "en"},
+            "relationships": [{"type": "scanlation_group", "id": "group1"}],
+        }
+    )
+    grouped_chapters, scanlation_groups = ChapterEntityDB.group_chapters([chapter_a, chapter_b, chapter_c])
+    assert grouped_chapters == {
+        1.0: [chapter_a],
+        2.0: [chapter_b],
+        3.0: [chapter_c],
+    }
+    assert scanlation_groups == ["group1", "group1", "group1"]
+
+
+@pytest.mark.parametrize(
+    "scanlation_groups, expected_priority_groups",
+    [
+        (["group1", "group2", "group1", "group3", "group2", "group1"], ["group1", "group2", "group3"]),
+        (
+            ["group1", "group2", "group1", "group3", "group2", "group1", "official"],
+            ["official", "group1", "group2", "group3"],
+        ),
+        (["group1", "group1", "group2", "group2", "group3"], ["group2", "group1", "group3"]),
+        (["group1", "group2", "group3"], ["group3", "group2", "group1"]),
+        (["group1"], ["group1"]),
+        (["group1", "group1", "group1", "official"], ["official", "group1"]),
+        ([], []),
+    ],
+)
+def test_get_priority_scanlation_groups(scanlation_groups, expected_priority_groups):
+    result = ChapterEntityDB.get_priority_scanlation_groups(scanlation_groups)
+    assert result == expected_priority_groups
+
+
+mock_chapter_group1 = MagicMock(scanlation_group="group1")
+mock_chapter_group2 = MagicMock(scanlation_group="group2")
+mock_chapter_group3 = MagicMock(scanlation_group="group3")
+
+
+@pytest.mark.parametrize(
+    "grouped_chapters, priority_groups, expected_filtered_chapters",
+    [
+        # Test case with single entries
+        (
+            {1: [mock_chapter_group1], 2: [mock_chapter_group2]},
+            ["group1", "group2"],
+            [mock_chapter_group1, mock_chapter_group2],
+        ),
+        # Test case with multiple entries and different priority groups
+        (
+            {1: [mock_chapter_group1, mock_chapter_group2], 2: [mock_chapter_group3]},
+            ["group2", "group1", "group3"],
+            [mock_chapter_group2, mock_chapter_group3],
+        ),
+        # Test case with multiple entries and same priority groups
+        (
+            {1: [mock_chapter_group1, mock_chapter_group2], 2: [mock_chapter_group2, mock_chapter_group1]},
+            ["group2", "group1"],
+            [mock_chapter_group2, mock_chapter_group2],
+        ),
+    ],
+)
+def test_filter_chapters_by_priority_scanlation_groups(grouped_chapters, priority_groups, expected_filtered_chapters):
+    result = ChapterEntityDB.filter_chapters_by_priority_scanlation_groups(grouped_chapters, priority_groups)
+    assert result == expected_filtered_chapters

--- a/tests/test_unit/test_database/test_chapter_entity_db.py
+++ b/tests/test_unit/test_database/test_chapter_entity_db.py
@@ -1,4 +1,7 @@
 from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
 
 from cbz_tagger.database.chapter_entity_db import ChapterEntityDB
 from cbz_tagger.entities.chapter_entity import ChapterEntity
@@ -44,3 +47,34 @@ def test_chapter_entity_db_can_store_and_load(chapter_request_response, manga_re
 
         new_json_str = new_entity_db.to_json()
         assert json_str == new_json_str
+
+
+def test_group_chapters():
+    chapter_a = ChapterEntity(
+        content={
+            "attributes": {
+                "chapter": "1",
+                "translatedLanguage": "en",
+            },
+            "relationships": [{"type": "scanlation_group", "id": "group1"}],
+        }
+    )
+    chapter_b = ChapterEntity(
+        content={
+            "attributes": {"chapter": "2", "translatedLanguage": "en"},
+            "relationships": [{"type": "scanlation_group", "id": "group2"}],
+        }
+    )
+    chapter_c = ChapterEntity(
+        content={
+            "attributes": {"chapter": "3", "translatedLanguage": "en"},
+            "relationships": [{"type": "scanlation_group", "id": "group3"}],
+        }
+    )
+    grouped_chapters, scanlation_groups = ChapterEntityDB.group_chapters([chapter_a, chapter_b, chapter_c])
+    assert grouped_chapters == {
+        1.0: [chapter_a],
+        2.0: [chapter_b],
+        3.0: [chapter_c],
+    }
+    assert scanlation_groups == ["group1", "group2", "group3"]


### PR DESCRIPTION
- If `official` group is present, it should be prioritized
- Split up the prioritization logic into 3 functions
- Add full test coverage for the different functions