### PR TITLE
Make volume map start at 0 instead of 1

### DIFF
--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -51,7 +51,9 @@ class VolumeEntity(BaseEntity):
         volume_ends = [item[1] for item in volume_list][1:] + [final_volume_chapter]
 
         volume_map = []
-        for (volume_key, volume_start, _), volume_end in zip(volume_list, volume_ends):
+        for idx, ((volume_key, volume_start, _), volume_end) in enumerate(zip(volume_list, volume_ends)):
+            if idx == 0:
+                volume_start = 0.0
             volume_map.append((volume_key, volume_start, volume_end))
 
         return volume_map

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -45,7 +45,7 @@ def test_volume_entity(volume_request_response):
         "2": ["19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2"],
         "1": ["19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1"],
     }
-    assert entity.volume_map == [("1", 1.0, 2.0), ("2", 2.0, 3.0), ("3", 3.0, 13.0), ("4", 13.0, 22.0)]
+    assert entity.volume_map == [("1", 0.0, 2.0), ("2", 2.0, 3.0), ("3", 3.0, 13.0), ("4", 13.0, 22.0)]
 
 
 def test_volume_entity_with_broken_chapters(volume_request_response):
@@ -94,7 +94,8 @@ def test_volume_entity_with_broken_chapters(volume_request_response):
         ("40", "6"),
         ("50", "7"),
         ("100", "12"),
-        ("0", "-1"),
+        ("0", "1"),
+        ("-1", "-1"),
     ],
 )
 def test_volume_entity_get_volume_for_chapter(volume_request_response, chapter, expected_volume):


### PR DESCRIPTION
Sometimes things start at `0` or `0.X`. These should be included in the first volume mapping and not default to a "-1" lookup (the latest art).