### PR TITLE
Adjust the retrieval order of covers

### DIFF
--- a/cbz_tagger/database/cover_entity_db.py
+++ b/cbz_tagger/database/cover_entity_db.py
@@ -66,10 +66,10 @@ class CoverEntityDB(BaseEntityDB):
         # Filter only english and japanese covers
         if len(_filter_content(content, "ja")) > 0:
             return _filter_content(content, "ja")
-        if len(_filter_content(content, "en")) > 0:
-            return _filter_content(content, "en")
         if len(_filter_content(content, "ko")) > 0:
             return _filter_content(content, "ko")
+        if len(_filter_content(content, "en")) > 0:
+            return _filter_content(content, "en")
         if len(_filter_content(content, "zh")) > 0:
             return _filter_content(content, "zh")
         return content


### PR DESCRIPTION
# Description
Adjust the retrieval order to allow for korean based comics. When retrieving `ja` -> `en` this can cause some weirdness for korean stuff. In reality `en` is more of a last resort and shouldn't really be used since its often fairly incomplete and the covers generally look more off. This doesn't break anything anywhere, its more a functionality tweak.

## Type of change
Select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[//]: # (### Fixes # &#40;issue&#41;)

[//]: # ()
[//]: # (If this fixes an existing issue, please link the issue here or delete this section.)
