### PR TITLE
Add support for using the original language as the language ISO code

### DIFF
--- a/cbz_tagger/database/entity_db.py
+++ b/cbz_tagger/database/entity_db.py
@@ -451,7 +451,7 @@ class EntityDB:
         assign("Colorist", artist_name)
         assign("Letterer", artist_name)
         assign("CoverArtist", artist_name)
-        assign("LanguageISO", "en")
+        assign("LanguageISO", self.metadata[entity_id].language)
         assign("Manga", "Yes")
         assign("Genre", ",".join(self.metadata[entity_id].genres))
         assign("AgeRating", self.metadata[entity_id].age_rating)

--- a/cbz_tagger/entities/metadata_entity.py
+++ b/cbz_tagger/entities/metadata_entity.py
@@ -115,6 +115,14 @@ class MetadataEntity(BaseEntity):
         return datetime.strptime(self.attributes["createdAt"].split("+")[0], "%Y-%m-%dT%H:%M:%S")
 
     @property
+    def language(self) -> str:
+        language_iso = self.attributes.get("originalLanguage", "en")
+        if language_iso is None or len(language_iso) > 2:
+            return "en"
+        language_iso = language_iso.lower()
+        return language_iso
+
+    @property
     def genres(self) -> List[str]:
         tags = list(
             attr.get("attributes", {}).get("name", {}).get("en")

--- a/tests/fixtures/expected_chapter_1.xml
+++ b/tests/fixtures/expected_chapter_1.xml
@@ -15,7 +15,7 @@
 	<Colorist>Kawasaki Tadataka</Colorist>
 	<Letterer>Kawasaki Tadataka</Letterer>
 	<CoverArtist>Kawasaki Tadataka</CoverArtist>
-	<LanguageISO>en</LanguageISO>
+	<LanguageISO>ja</LanguageISO>
 	<Manga>Yes</Manga>
 	<Genre>Seinen,Anthology,Comedy,Romance,School Life,Slice of Life</Genre>
 	<AgeRating>Teen</AgeRating>

--- a/tests/fixtures/expected_chapter_10.xml
+++ b/tests/fixtures/expected_chapter_10.xml
@@ -15,7 +15,7 @@
 	<Colorist>Kawasaki Tadataka</Colorist>
 	<Letterer>Kawasaki Tadataka</Letterer>
 	<CoverArtist>Kawasaki Tadataka</CoverArtist>
-	<LanguageISO>en</LanguageISO>
+	<LanguageISO>ja</LanguageISO>
 	<Manga>Yes</Manga>
 	<Genre>Seinen,Anthology,Comedy,Romance,School Life,Slice of Life</Genre>
 	<AgeRating>Teen</AgeRating>

--- a/tests/fixtures/expected_chapter_1_with_count_3.xml
+++ b/tests/fixtures/expected_chapter_1_with_count_3.xml
@@ -15,7 +15,7 @@
 	<Colorist>Kawasaki Tadataka</Colorist>
 	<Letterer>Kawasaki Tadataka</Letterer>
 	<CoverArtist>Kawasaki Tadataka</CoverArtist>
-	<LanguageISO>en</LanguageISO>
+	<LanguageISO>ja</LanguageISO>
 	<Manga>Yes</Manga>
 	<Genre>Seinen,Anthology,Comedy,Romance,School Life,Slice of Life</Genre>
 	<AgeRating>Teen</AgeRating>

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -12,6 +12,7 @@ def check_entity_download_links(entity, entity_link_count):
     assert response.status_code == 200
 
 
+# These are random selections of cancelled free web comics for testing the API connections
 @pytest.mark.parametrize(
     "entity_id,plugin_type,plugin_id,entity_count,first_entity_count,second_entity_count",
     [

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 
 from cbz_tagger.common.enums import Plugins
@@ -17,8 +19,9 @@ def check_entity_download_links(entity, entity_link_count):
     "entity_id,plugin_type,plugin_id,entity_count,first_entity_count,second_entity_count",
     [
         ("11afa5c2-41dc-4cf3-8451-f306a3caf1ab", Plugins.MDX, "", 132, 7, 7),
-        ("example_manga", Plugins.CMK, "isekai-ni-kita-mitai-dakedo-ikanisureba-yoi-no-darou", 8, 23, 39),
-        ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
+        ("example_manga", Plugins.CMK, "itadaki", 5, 21, 20),
+        # ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
+        # Disabled because the plugin is not working in tests consistently
     ],
 )
 def test_chapter_plugins_api_connection_test(

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 import pytest
 
 from cbz_tagger.common.enums import Plugins

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -16,7 +16,7 @@ def check_entity_download_links(entity, entity_link_count):
     "entity_id,plugin_type,plugin_id,entity_count,first_entity_count,second_entity_count",
     [
         ("11afa5c2-41dc-4cf3-8451-f306a3caf1ab", Plugins.MDX, "", 132, 7, 7),
-        ("example_manga", Plugins.CMK, "itadaki", 5, 21, 20),
+        ("example_manga", Plugins.CMK, "isekai-ni-kita-mitai-dakedo-ikanisureba-yoi-no-darou", 8, 23, 39),
         ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
     ],
 )

--- a/tests/test_unit/test_entities/test_metadata_entity.py
+++ b/tests/test_unit/test_entities/test_metadata_entity.py
@@ -111,13 +111,9 @@ def test_demographic_none():
         ({"originalLanguage": "zh"}, "zh"),
         ({"originalLanguage": "ko"}, "ko"),
         ({"originalLanguage": "japanese"}, "en"),  # Invalid ISO code, should default to "en"
+        ({}, "en"),  # Missing field, should default to "en"
     ],
 )
 def test_language_with_different_attributes(attributes, expected_language):
     entity = MetadataEntity(content={"attributes": attributes})
     assert entity.language == expected_language
-
-
-def test_language_with_missing_field():
-    entity = MetadataEntity(content={"attributes": {}})
-    assert entity.language == "en"

--- a/tests/test_unit/test_entities/test_metadata_entity.py
+++ b/tests/test_unit/test_entities/test_metadata_entity.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from unittest import mock
 
+import pytest
+
 from cbz_tagger.entities.base_entity import BaseEntity
 from cbz_tagger.entities.metadata_entity import MetadataEntity
 
@@ -32,6 +34,7 @@ def test_metadata_entity(manga_request_content):
     assert entity.created_at == datetime.strptime("2020-07-23 14:50:37", "%Y-%m-%d %H:%M:%S")
     assert entity.genres == ["Seinen", "Anthology", "Comedy", "Romance", "School Life", "Slice of Life"]
     assert entity.demographic == "Seinen"
+    assert entity.language == "ja"
 
 
 def test_metadata_entity_does_not_store_extra_descriptions(manga_request_content):
@@ -97,3 +100,24 @@ def test_demographic_none():
     attributes = {"publicationDemographic": None}
     entity = MetadataEntity(content={"attributes": attributes})
     assert entity.demographic is None
+
+
+@pytest.mark.parametrize(
+    "attributes, expected_language",
+    [
+        ({"originalLanguage": None}, "en"),
+        ({"originalLanguage": "en"}, "en"),
+        ({"originalLanguage": "ja"}, "ja"),
+        ({"originalLanguage": "zh"}, "zh"),
+        ({"originalLanguage": "ko"}, "ko"),
+        ({"originalLanguage": "japanese"}, "en"),  # Invalid ISO code, should default to "en"
+    ],
+)
+def test_language_with_different_attributes(attributes, expected_language):
+    entity = MetadataEntity(content={"attributes": attributes})
+    assert entity.language == expected_language
+
+
+def test_language_with_missing_field():
+    entity = MetadataEntity(content={"attributes": {}})
+    assert entity.language == "en"


### PR DESCRIPTION
# Description
This is a bit of a nuanced change. I've realized over time that defaulting all the LangaugeISO to english sort of blurs out information which might otherwise be useful. Specifically, some original content is japanese, english, korean, etc. To allow comics to actually be filtered correctly, they should contain the appropriate original language iso information.

One area where I am a bit conflicted on this change is translated content. This could go either way, but its very hard to know if something is/isn't translated. Because of this I think defaulting to the original language probably makes the most sense.

## Type of change
Select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[//]: # (### Fixes # &#40;issue&#41;)

[//]: # ()
[//]: # (If this fixes an existing issue, please link the issue here or delete this section.)
