### PR TITLE
Fix no volumes available return list instead of dict

### DIFF
--- a/cbz_tagger/entities/volume_entity.py
+++ b/cbz_tagger/entities/volume_entity.py
@@ -20,7 +20,10 @@ class VolumeEntity(BaseEntity):
 
     @property
     def aggregate(self):
-        return self.content.get("volumes", {})
+        volumes = self.content.get("volumes", {})
+        if isinstance(volumes, list):
+            return {}
+        return volumes
 
     @property
     def volumes(self):

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -19,8 +19,7 @@ def check_entity_download_links(entity, entity_link_count):
         ("11afa5c2-41dc-4cf3-8451-f306a3caf1ab", Plugins.MDX, "", 132, 7, 7),
         ("example_manga", Plugins.CMK, "itadaki", 5, 21, 20),
         ("example_manga", Plugins.KAL, "23032-umbella", 3, 3, 3),
-        # ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
-        # Disabled because the plugin is not working in tests consistently
+        ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
     ],
 )
 def test_chapter_plugins_api_connection_test(

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -659,6 +659,14 @@ def volume_request_response():
 
 
 @pytest.fixture
+def volume_request_response_none_available():
+    return {
+        "result": "ok",
+        "volumes": [],
+    }
+
+
+@pytest.fixture
 def cover_request_response():
     return {
         "result": "ok",

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -60,7 +60,7 @@ def test_volume_entity_with_no_data_available(volume_request_response_none_avail
     assert entity.chapter_count == 0
     assert sorted(entity.chapters) == []
     assert entity.volumes == {}
-    assert entity.volume_map == [('-1', 0.0, 0.0)]
+    assert entity.volume_map == [("-1", 0.0, 0.0)]
 
 
 def test_volume_entity_with_broken_chapters(volume_request_response):

--- a/tests/test_unit/test_entities/test_volume_entity.py
+++ b/tests/test_unit/test_entities/test_volume_entity.py
@@ -48,6 +48,21 @@ def test_volume_entity(volume_request_response):
     assert entity.volume_map == [("1", 0.0, 2.0), ("2", 2.0, 3.0), ("3", 3.0, 13.0), ("4", 13.0, 22.0)]
 
 
+def test_volume_entity_with_no_data_available(volume_request_response_none_available):
+    entity = VolumeEntity(content=volume_request_response_none_available)
+
+    # Volume entities are very simple and have little metadata
+    assert entity.entity_id is None
+    assert entity.entity_type is None
+    assert entity.attributes == {}
+    assert entity.relationships == {}
+
+    assert entity.chapter_count == 0
+    assert sorted(entity.chapters) == []
+    assert entity.volumes == {}
+    assert entity.volume_map == [('-1', 0.0, 0.0)]
+
+
 def test_volume_entity_with_broken_chapters(volume_request_response):
     entity = VolumeEntity(content=volume_request_response)
 


### PR DESCRIPTION
# Description
Main api which returns volumes has a breaking change wherein instead of returning an empty dict or `None`, like is specified in the swagger docs, it can return an empty list. This then can't be iterated on or used, and just breaks things. This adds a new test and check that if a list is returned then it should instead be treated as an empty dict.

I've also re-enabled the WBC tests since these seem to have resolved themselves on their own.

## Type of change
Select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[//]: # (### Fixes # &#40;issue&#41;)

[//]: # ()
[//]: # (If this fixes an existing issue, please link the issue here or delete this section.)
