### PR TITLE
Disable WBC but don't remove it for now, enable KAL

### DIFF
--- a/cbz_tagger/common/enums.py
+++ b/cbz_tagger/common/enums.py
@@ -40,7 +40,7 @@ class Plugins:
 
     @classmethod
     def all(cls):
-        return [cls.MDX, cls.CMK, cls.WBC]
+        return [cls.MDX, cls.WBC, cls.KAL]
 
 
 class Status:

--- a/tests/test_integration/test_chapter_plugins_api.py
+++ b/tests/test_integration/test_chapter_plugins_api.py
@@ -17,7 +17,6 @@ def check_entity_download_links(entity, entity_link_count):
     "entity_id,plugin_type,plugin_id,entity_count,first_entity_count,second_entity_count",
     [
         ("f2def508-4407-471c-bf2c-86bea3e4e592", Plugins.MDX, "", 14, 4, 1),
-        ("example_manga", Plugins.CMK, "itadaki", 5, 21, 20),
         ("example_manga", Plugins.KAL, "23032-umbella", 3, 3, 3),
         ("example_manga", Plugins.WBC, "01J76XY9B20J1KHJ1FWVZ8N1PK", 5, 21, 20),
     ],


### PR DESCRIPTION
# Description
Disable the `WBC` backend. It seems to be no longer working. Enable KAL. Tests are passing and I forgot how to use it, but it seems to work.

## Type of change
Select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[//]: # (### Fixes # &#40;issue&#41;)

[//]: # ()
[//]: # (If this fixes an existing issue, please link the issue here or delete this section.)
