### PR TITLE
Fix bad last link

### DIFF
--- a/cbz_tagger/entities/chapter_plugins/kal.py
+++ b/cbz_tagger/entities/chapter_plugins/kal.py
@@ -61,6 +61,7 @@ class ChapterPluginKAL(ChapterPluginEntity):
             raise EnvironmentError("Could not find chapter images")
 
         chapter_images = chapter_images.strip().replace('var chapImages = "', "")
+        chapter_images = chapter_images.replace('";', "")
         pages = chapter_images.split(",")
 
         links = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cbz_tagger"
-version = "3.14.0"
+version = "3.14.1"
 description = "CBZ Tagger is a tool to tag comic book files in CBZ format"
 authors = [
     {name = "Matt Nitzken",email = "mjnitz02@gmail.com"}

--- a/tests/test_unit/test_entities/test_plugin_kal.py
+++ b/tests/test_unit/test_entities/test_plugin_kal.py
@@ -123,5 +123,5 @@ def test_parse_chapter_download_links(chapter_entity):
     assert result == [
         "https://site.com/chapter-5/6841338_720_4030_548075.webp",
         "https://site.com/chapter-5/6841339_720_4030_437011.webp",
-        'https://site.com/chapter-5/6841340_720_1242_156219.webp";',
+        "https://site.com/chapter-5/6841340_720_1242_156219.webp",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "cbz-tagger"
-version = "3.14.0"
+version = "3.14.1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description
Weird `";` was being leftover in the last link in KAL scans

## Type of change
Select options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[//]: # (### Fixes # &#40;issue&#41;)

[//]: # ()
[//]: # (If this fixes an existing issue, please link the issue here or delete this section.)
